### PR TITLE
[WIP] Refactor dependencies retrieval

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'pkgwat'
 gem 'bicho'
 gem 'ruby-bugzilla'
 gem 'text'
+gem 'awesome_spawn'
 
 gem 'whenever', :require => false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
     arel (4.0.2)
     ast (2.0.0)
     awesome_print (1.2.0)
+    awesome_spawn (1.2.1)
     bicho (0.0.6)
       highline (~> 1.6.2)
       inifile (~> 0.4.1)
@@ -355,6 +356,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  awesome_spawn
   bicho
   bootstrap-sass
   bootstrap-will_paginate

--- a/app/controllers/fedorarpms_controller.rb
+++ b/app/controllers/fedorarpms_controller.rb
@@ -11,7 +11,7 @@ class FedorarpmsController < ApplicationController
     @name = params[:id]
     @rpm = FedoraRpm.find_by(name: @name)
     @page_title = @rpm.name
-    @dependencies = @rpm.dependency_packages
+    @dependencies = @rpm.dependencies_environment
     @dependents = @rpm.dependent_packages.uniq
     # We can register a global error handler inside the application controller for this.
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/fedorarpms_controller.rb
+++ b/app/controllers/fedorarpms_controller.rb
@@ -9,9 +9,9 @@ class FedorarpmsController < ApplicationController
 
   def show
     @name = params[:id]
-    @rpm = FedoraRpm.find_by_name! @name
+    @rpm = FedoraRpm.find_by(name: @name)
     @page_title = @rpm.name
-    @dependencies = @rpm.dependency_packages.uniq
+    @dependencies = @rpm.dependency_packages
     @dependents = @rpm.dependent_packages.uniq
     # We can register a global error handler inside the application controller for this.
     rescue ActiveRecord::RecordNotFound
@@ -25,7 +25,7 @@ class FedorarpmsController < ApplicationController
 
   def full_deps
     @name = params[:id]
-    @rpm = FedoraRpm.find_by_name(@name)
+    @rpm = FedoraRpm.find_by(name: @name)
     respond_to do |format|
       format.html
     end
@@ -33,7 +33,7 @@ class FedorarpmsController < ApplicationController
 
   def full_dependencies
     @name = params[:id]
-    @rpm = FedoraRpm.find_by_name(@name)
+    @rpm = FedoraRpm.find_by(name: @name)
     respond_to do |format|
       format.json { render json: @rpm.json_dependencies }
     end
@@ -41,7 +41,7 @@ class FedorarpmsController < ApplicationController
 
   def full_dependents
     @name = params[:id]
-    @rpm = FedoraRpm.find_by_name(@name)
+    @rpm = FedoraRpm.find_by(name: @name)
     respond_to do |format|
       format.json { render json: @rpm.json_dependents }
     end

--- a/app/models/fedora_rpm.rb
+++ b/app/models/fedora_rpm.rb
@@ -202,7 +202,8 @@ class FedoraRpm < ActiveRecord::Base
     dependencies.clear
 
     # Runtime (Requires)
-    cmd = `repoquery --repoid=rawhide --requires --resolve #{name} --qf="%{NAME}"`
+    query = "repoquery --repoid=rawhide --requires --resolve #{name} --qf=\"%{NAME}\""
+    cmd = AwesomeSpawn.run(query).output
     cmd.lines.map(&:chomp).select { |v| v.start_with? 'rubygem-' }.each do |line|
       d = Dependency.new
       d.dependent = line.split('-', 2).last

--- a/app/models/fedora_rpm.rb
+++ b/app/models/fedora_rpm.rb
@@ -226,6 +226,19 @@ class FedoraRpm < ActiveRecord::Base
     end
   end
 
+  # Returns an array of dependencies in a FedoraRpm format
+  def dependency_packages
+    dependencies.map do |d|
+      FedoraRpm.where(name: "rubygem-#{d.dependent}").to_a
+    end.compact.flatten
+  end
+
+  def dependent_packages
+    Dependency.where(dependent: shortname).map do |d|
+      d.package if d.package.is_a?(FedoraRpm)
+    end.compact
+  end
+
   def json_dependencies(packages = [])
     children = []
     dependency_packages.each do |p|
@@ -246,19 +259,6 @@ class FedoraRpm < ActiveRecord::Base
       end
     end
     { name: shortname, children: children }
-  end
-
-  # Returns an array of dependencies in a FedoraRpm format
-  def dependency_packages
-    dependencies.map do |d|
-      FedoraRpm.where(name: "rubygem-#{d.dependent}").to_a
-    end.compact.flatten
-  end
-
-  def dependent_packages
-    Dependency.where(dependent: shortname).map do |d|
-      d.package if d.package.is_a?(FedoraRpm)
-    end.compact
   end
 
   def retrieve_gem

--- a/app/models/fedora_rpm.rb
+++ b/app/models/fedora_rpm.rb
@@ -226,6 +226,20 @@ class FedoraRpm < ActiveRecord::Base
     end
   end
 
+  # Returns an array of arrays containing dependencies with their environment
+  # Environment can be runtime, development or dev/runtime. Exclude double
+  # values.
+  def dependencies_environment
+    self.dependencies.reduce({}) do |hash, elmt|
+      if hash["rubygem-#{elmt.dependent}"]
+        hash["rubygem-#{elmt.dependent}"] = 'dev/runtime'
+      else
+        hash["rubygem-#{elmt.dependent}"] = elmt.environment
+      end
+      hash
+    end.to_a
+  end
+
   # Returns an array of dependencies in a FedoraRpm format
   def dependency_packages
     dependencies.map do |d|

--- a/app/views/fedorarpms/show.html.haml
+++ b/app/views/fedorarpms/show.html.haml
@@ -20,7 +20,7 @@
       = link_to 'Builds', '#builds', { data: {toggle: 'tab'}, role: 'tab' }
   %p
   .tab-content.span12#fedorarpm-show
-    .tab-pane.fade.in.active#info
+    .tab-pane.in.active#info
       - unless @rpm.ruby_gem.nil?
         = button_to "#{@rpm.ruby_gem.name}.gem", rubygem_path(@rpm.ruby_gem.name),
         :class => 'btn btn-success', :type => 'button', :method => :get
@@ -62,7 +62,7 @@
           Description:
           =@rpm.description
 
-    .tab-pane.fade#versions
+    .tab-pane#versions
       .table-responsive
         %table.table.table-hover.table-condensed
           %thead
@@ -76,7 +76,7 @@
                 %td= @rpm.version_for(t)
               %td= @rpm.ruby_gem.version
 
-    .tab-pane.fade#dependencies
+    .tab-pane#dependencies
       %h3
         = link_to 'Dependency Tree', controller: 'fedorarpms',
                                      action: 'full_deps'
@@ -93,20 +93,20 @@
                   %tr.warning
                     %th Package
                     %th Environment
-                    -FedoraRpm.fedora_versions.each do |t, g|
+                    -FedoraRpm.fedora_versions.each do |_t, g|
                       - if g == 'master'
                         %th= 'Rawhide'
                       - else
                         %th= g
                     %th= _('Upstream')
                 %tbody
-                  - @dependencies.each do |d|
+                  - @rpm.dependencies.each do |d|
                     %tr
-                      %td= link_to d.name, fedorarpm_path(d.name)
-                      %td= @rpm.dependencies.find_by(dependent: d.shortname).environment
-                      -FedoraRpm.fedora_versions.each do |t, g|
-                        %td= d.version_for(t)
-                      %td= d.ruby_gem.version
+                      %td= link_to d.dependent, fedorarpm_path(FedoraRpm.find(d.package_id).to_param)
+                      %td= d.environment
+                      -FedoraRpm.fedora_versions.each do |t, _g|
+                        %td= FedoraRpm.find_by(name: "rubygem-#{d.dependent}").version_for(t)
+                      %td= FedoraRpm.find(d.package_id).ruby_gem.version
 
         %div.col-md-6
           - if @dependents.blank?
@@ -128,12 +128,12 @@
                 %tbody
                   - @dependents.each do |d|
                     %tr
-                      %td= link_to d.name, fedorarpm_path(d.name)
+                      %td= link_to d.shortname, fedorarpm_path(d.name)
                       -FedoraRpm.fedora_versions.each do |t, g|
                         %td= d.version_for(t)
                       %td= d.ruby_gem.version
 
-    .tab-pane.fade#bugs
+    .tab-pane#bugs
       - if @rpm.bugs.blank?
         %h4 No bugs found!
       - else
@@ -151,7 +151,7 @@
                   %td
                     = b.name.truncate(60)
 
-    .tab-pane.fade#builds
+    .tab-pane#builds
       .table-responsive
         %table.table.table-hover.table-condensed
           %thead

--- a/app/views/fedorarpms/show.html.haml
+++ b/app/views/fedorarpms/show.html.haml
@@ -100,13 +100,14 @@
                         %th= g
                     %th= _('Upstream')
                 %tbody
-                  - @rpm.dependencies.each do |d|
+                  - @dependencies.each do |d|
                     %tr
-                      %td= link_to d.dependent, fedorarpm_path(FedoraRpm.find(d.package_id).to_param)
-                      %td= d.environment
+                      %td= link_to d.first.gsub(/rubygem-/,''),
+                        fedorarpm_path(d.first)
+                      %td= d.last
                       -FedoraRpm.fedora_versions.each do |t, _g|
-                        %td= FedoraRpm.find_by(name: "rubygem-#{d.dependent}").version_for(t)
-                      %td= FedoraRpm.find(d.package_id).ruby_gem.version
+                        %td= FedoraRpm.find_by(name: d.first).version_for(t)
+                      %td= FedoraRpm.find_by(name: d.first).ruby_gem.version
 
         %div.col-md-6
           - if @dependents.blank?


### PR DESCRIPTION
There is no way at this point to fetch the information via an API. We have to use `repoquery` instead. That limits us to production OS running Fedora though.

TODO
- [x] Mark the environment column as `dev/runtime` if a dependency is both runtime/development.
- [x] Split runtime and development dependencies in separate methods
- [ ] Add tests
